### PR TITLE
fix: use registry cache instead of GHA cache for persistent Docker la…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,6 @@ jobs:
         run: make test-e2e
         env:
           DOCKER_BUILDKIT: 1
-          CACHE_TYPE: gha
-          CACHE_MODE: max
 
   push-images:
     runs-on: ubuntu-latest
@@ -115,9 +113,6 @@ jobs:
           [ "$VERSION" == "master" ] && VERSION=latest
           echo "PROJECT_VERSION=$VERSION" >> $GITHUB_ENV
           IMAGE_VERSION=$VERSION make push-images
-        env:
-          CACHE_TYPE: gha
-          CACHE_MODE: max
 
       - name: Get Changelog Entry
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
…yer caching

GHA cache expires after 7 days and is not shared across workflows. Using registry cache (--cache-to type=registry,mode=max) persists cache in the container registry alongside images, enabling faster builds across all CI runs and local development.