### PR TITLE
fix: improve Docker cache strategy for CI and local builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
         run: make test-e2e
         env:
           DOCKER_BUILDKIT: 1
+          CACHE_TYPE: gha
+          CACHE_MODE: max
 
   push-images:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,10 @@ CACHE_TYPE ?= registry
 CACHE_MODE ?= max
 
 ifeq ($(CACHE_TYPE),gha)
-CACHE_FROM_BUILD := --cache-from type=gha
-CACHE_FROM_BASE := --cache-from type=gha
-CACHE_FROM_SERVER := --cache-from type=gha
-CACHE_FROM_WORKER := --cache-from type=gha
+CACHE_FROM_BUILD := --cache-from type=gha --cache-from type=registry,ref=$(IMAGE_NAME):latest-build
+CACHE_FROM_BASE := --cache-from type=gha --cache-from type=registry,ref=$(IMAGE_NAME):latest-base
+CACHE_FROM_SERVER := --cache-from type=gha --cache-from type=registry,ref=$(IMAGE_NAME):latest-server
+CACHE_FROM_WORKER := --cache-from type=gha --cache-from type=registry,ref=$(IMAGE_NAME):latest-worker
 CACHE_TO_BUILD := --cache-to type=gha,mode=$(CACHE_MODE)
 CACHE_TO_BASE := --cache-to type=gha,mode=$(CACHE_MODE)
 CACHE_TO_SERVER := --cache-to type=gha,mode=$(CACHE_MODE)


### PR DESCRIPTION
- E2E tests: Use GHA cache + registry cache as fallback
- Push images: Use registry cache (persistent across CI runs)
- GHA cache mode: Use both --cache-from type=gha and --cache-from type=registry

This ensures:
1. CI builds are fast using GHA cache within workflow
2. Registry cache persists for local builds and future CI runs
3. Push-images saves cache to registry for reuse